### PR TITLE
allow script to get dependencies on my mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Michael Erasmus <michael@buffer.com>
 
 #add repository and update the container
 #Installation of nesesary package/software for this containers...
-RUN (echo "deb http://cran.rstudio.com/bin/linux/ubuntu wily/" >> /etc/apt/sources.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9)
+RUN (echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9)
 RUN apt-get update
 RUN apt-get install -y -q r-base  \
                     r-base-dev \


### PR DESCRIPTION
fixes #26 

The script was trying to get a package for the ubuntu version `wily` which is not supported anymore and is not an LTS, replacing by `trusty` which is LTS, still supported and older than `wily` (so compatible) did the trick

paired with @florianmski